### PR TITLE
Replaced the link to download the tar-zipped Chandra CalDB in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
               mkdir -p /home/jovyan/chandra-caldb
 
               # Download the Chandra CalDB
-              wget https://cxc.cfa.harvard.edu/cdaftp/arcftp/caldb/caldb_${CHANDRA_CALDB_VER}_main.tar.gz
+              wget https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB/tars/caldb_${CHANDRA_CALDB_VER}_main.tar.gz
 
               # Unpack the archive into a specific directory
               tar xzf caldb_${CHANDRA_CALDB_VER}_main.tar.gz -C /home/jovyan/chandra-caldb


### PR DESCRIPTION
A new version of the CalDB (4.12.3) has been released, and apparently the link I was using and populating with the version string only points to the latest version. The new link points to a directory with multiple (including the latest) versions of the Chandra CalDB.
