### PR TITLE
Added weekly lychee link checking for HEASARC-tutorials files

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,27 @@
+name: Check HEASARC-tutorials for broken links
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 8:30am (EST) on mondays - GitHub cron jobs are specified in UTC
+    - cron: "30 13 * * 1"
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the main branch - we'll check all the markdown files
+      - uses: actions/checkout@v6.0.1
+        with:
+          ref: main
+          path: heasarc-tutorials-main
+
+      # The point of this action - running a link checker on the files in the main branch.
+      - name: Search for broken links in HEASARC-tutorials files
+        id: lychee
+        uses: lycheeverse/lychee-action@v2.7.0
+        with:
+          args: --root-dir "$(pwd)" --verbose --no-progress './**/*.md' './**/*.html' --exclude-path '_static'
+          fail: true
+          format: markdown
+          workingDirectory: heasarc-tutorials-main


### PR DESCRIPTION
Runs on the markdown files in main branch - considered running it on gh-pages but it didn't really seem to work very well for some reason, and this was easier. Should close issue #130

Will run on Mondays at 8:30am EST (hopefully).

Any broken links will result in a failed run, though if necessary in the future it could also be used to open an issue.