### PR TITLE
Now accept code 403 in Lychee link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,4 +1,4 @@
-name: Check HEASARC-tutorials for broken links
+name: Broken link identifier
 
 # Three ways to trigger this link checker:
 #  1. Automatically, once a week on a regular schedule
@@ -24,11 +24,12 @@ jobs:
           path: heasarc-tutorials-main
 
       # The point of this action - running a link checker on the files in the main branch.
-      - name: Search for broken links in HEASARC-tutorials files
+      - name: Find broken links [HEASARC-tutorials]
         id: lychee
         uses: lycheeverse/lychee-action@v2.7.0
         with:
-          args: --root-dir "$(pwd)" --verbose --no-progress './**/*.md' './**/*.html' --exclude-path '_static'
+          args: --root-dir "$(pwd)" --accept '100..=103,200..=299,403' --verbose --no-progress './**/*.md' './**/*.html' --exclude-path '_static'
           fail: true
           format: markdown
           workingDirectory: heasarc-tutorials-main
+          failIfEmpty: true


### PR DESCRIPTION
Altered the lychee link checking GHA so that it won't fail on code 403s, which get returned when the resource exists but the server won't grant access. That could in some cases mean that the permissions to a particular file have changed, which we would want to catch, but in the vast majority of cases I think it'll be websites with bot checkers etc.

We don't want to fail on it because they aren't really real failures, and I'm getting bored of all the emails from GitHub.

Also added an argument that will fail the lychee action if no links are found at all, because that really would indicate a problem.