### PR TITLE
Google analytics only enabled for production website

### DIFF
--- a/.github/workflows/build-publish-website.yml
+++ b/.github/workflows/build-publish-website.yml
@@ -16,6 +16,9 @@ env:
   # E.g., if your site lives at `https://mydomain.org/myproject`, set `BASE_URL=/myproject`.
   # If, instead, your site lives at the root of the domain, at `https://mydomain.org`, set `BASE_URL=''`.
   BASE_URL: /${{ github.event.repository.name }}
+  # This makes sure that sphinx-build's conf.py includes HEASARC-tutorial's Google analytics code
+  #  in the theme options, enabling tracking of production website visits etc.
+  HEASARC_TUTORIALS_ENABLE_ANALYTICS: true
 
 
 jobs:

--- a/conf.py
+++ b/conf.py
@@ -164,11 +164,23 @@ html_theme_options = {
         "text": f"v{version}",
     },
     "home_page_in_toc": False,
-    "announcement": "<p class='beta-banner'>The HEASARC tutorials resource is in <strong>BETA</strong> and may be subject to significant changes.</p>",
-    "analytics": {
-      "google_analytics_id": "G-R7YGYK7HYQ"
-    }
+    "announcement": "<p class='beta-banner'>The HEASARC tutorials resource is in <strong>BETA</strong> and may be subject to significant changes.</p>"
 }
+
+# We only want the analytics to be enabled for the production build and website, otherwise
+#  whatever data we collect from them will be tainted by our looking at local versions
+#  of the website or test builds on CircleCI.
+# The GHA that builds the production website will set this environment variable to 'true'
+if 'HEASARC_TUTORIALS_ENABLE_ANALYTICS' in os.environ:
+    enable_analytics = bool(os.environ['HEASARC_TUTORIALS_ENABLE_ANALYTICS'])
+else:
+    enable_analytics = False
+
+# If analytics are enabled, add the Google Analytics ID to the theme options
+if enable_analytics:
+    html_theme_options["analytics"] = {
+        "google_analytics_id": "G-R7YGYK7HYQ"
+    }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This will stop us tainting the data we collect with local versions and test builds on CircleCI