### PR TITLE
Fixed broken cross-reference in NuSTAR notebook

### DIFF
--- a/tutorials/mission_specific_analyses/nustar/data-analysis-nustar.md
+++ b/tutorials/mission_specific_analyses/nustar/data-analysis-nustar.md
@@ -118,8 +118,6 @@ SOURCE = "SWIFT J2127.4+5654"
 
 # The ObsID of the observation we wish to use
 OBS_ID = "60001110002"
-
-WORK_DIR = "REMOVE"
 ```
 
 ### Configuration


### PR DESCRIPTION
There was an issue in the production website build where a cross reference to the HEASoftPy introduction notebook was broken because it was pointing to the md version.

Hopefully that is now fixed?