### PR TITLE
Install Astroquery prerelease in catalog-contents bitesize notebook

### DIFF
--- a/fornax-manifest.yml
+++ b/fornax-manifest.yml
@@ -104,3 +104,12 @@ notebooks:
     extra-dependencies:
     requirements-file:
     keywords: [ ]
+
+  - path: mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.md
+    executed-path: mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.ipynb
+    title: Getting started with ROSAT All Sky Survey data
+    description: Demonstrates how to use Python to generate new images and spectra for a sample of objects from ROSAT All-Sky Survey (RASS) data.
+    fornax-env: heasoft
+    extra-dependencies:
+    requirements-file:
+    keywords: [ ]

--- a/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
+++ b/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
@@ -51,7 +51,7 @@ tags: [hide-output]
 jupyter:
   output_hidden: true
 ---
-!pip install --pre astroquery --upgrade
+%pip install --pre astroquery --upgrade
 ```
 
 ```{code-cell} python

--- a/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
+++ b/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
@@ -80,7 +80,7 @@ default, which is why the table below contains only a few column names, descript
 units even though this catalog has *79* columns:
 
 ```{code-cell} python
-# Pass the name of the catalog as the first argument
+# We pass the name of the catalog as the first argument
 Heasarc.list_columns("acceptcat")
 ```
 

--- a/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
+++ b/tutorials/heasarc_service_skills/heasarc_catalogs/heasarc_catalog_contents.md
@@ -5,7 +5,7 @@ authors:
   email: djturner@umbc.edu
   orcid: 0000-0001-9658-1396
   website: https://davidt3.github.io/
-date: '2026-03-05'
+date: '2026-03-16'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -37,7 +37,7 @@ To learn how to use Python to search for a particular HEASARC catalog, please se
 
 ### Runtime
 
-As of 5th March 2026, this notebook takes ~30 s to run to completion on Fornax using the 'small' server with 8GB RAM/ 2 cores.
+As of 16th March 2026, this notebook takes ~30 s to run to completion on Fornax using the 'small' server with 8GB RAM/ 2 cores.
 
 ## Imports
 
@@ -45,8 +45,13 @@ This notebook uses features from an Astroquery pre-release. You will need to ins
 the latest version using the command below. We will remove this once Astroquery
 v0.4.12 is officially released.
 
-```
-pip install --pre astroquery --upgrade
+```{code-cell} python
+---
+tags: [hide-output]
+jupyter:
+  output_hidden: true
+---
+!pip install --pre astroquery --upgrade
 ```
 
 ```{code-cell} python
@@ -243,7 +248,7 @@ accept_cat_higherz_lowk_pd
 
 Author: David Turner, HEASARC Staff Scientist
 
-Updated On: 2026-03-05
+Updated On: 2026-03-16
 
 +++
 

--- a/tutorials/heasarc_service_skills/heasarc_catalogs/uploading_matching_table_heasarc_catalogs.md
+++ b/tutorials/heasarc_service_skills/heasarc_catalogs/uploading_matching_table_heasarc_catalogs.md
@@ -55,7 +55,7 @@ tags: [hide-output]
 jupyter:
   output_hidden: true
 ---
-!pip install --pre astroquery --upgrade
+%pip install --pre astroquery --upgrade
 ```
 
 ```{code-cell} python

--- a/tutorials/heasarc_service_skills/heasarc_catalogs/uploading_matching_table_heasarc_catalogs.md
+++ b/tutorials/heasarc_service_skills/heasarc_catalogs/uploading_matching_table_heasarc_catalogs.md
@@ -80,7 +80,7 @@ First, we define the path to the CSV file (I know it isn't really a 'local' file
 you could set this to the path to a CSV on your machine that you wish to cross-match!):
 
 ```{code-cell} python
-# URL of a sample file
+# Set up URL of a sample file
 samp_path = (
     "https://github.com/DavidT3/XCS-Mass-II-Analysis/raw/refs/heads/main/"
     "sample_files/SDSSRM-XCS_base_sample.csv"


### PR DESCRIPTION
Restoring the in-notebook installation of the Astroquery pre release to the bite sized tutorial on interacting with the contents of a HEASARC-hosted catalog.

It was previously removed because I mistakenly thought it was causing table rendering issues, but that wasn't correct.

Also belatedly added the RASS getting started notebook to the Fornax manifest file.