### PR TITLE
Upped CIAO CalDB version to match Fornax-main and fixed older-than-current version download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # YAML anchor for the support data versions
 .version-env: &version-env
   environment:
-    CHANDRA_CALDB_VER: 4.12.2
+    CHANDRA_CALDB_VER: 4.12.3
     CIRCLECI_XMM_CCF_VER: 1
     XSPEC_DATA_VER: 6.36
 
@@ -354,12 +354,43 @@ jobs:
               [ -d chandra-caldb ] && rm -rf chandra-caldb
               mkdir -p chandra-caldb
 
-              # Download the Chandra CalDB
-              wget https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB/tars/caldb_${CHANDRA_CALDB_VER}_main.tar.gz
+              # Define file and URLs
+              TAR_FILE="caldb_${CHANDRA_CALDB_VER}_main.tar.gz"
+              MAIN_URL="https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB/tars/${TAR_FILE}"
+
+              # Check if the requested version is the latest one stored in the main directory
+              if wget -q --spider "$MAIN_URL"; then
+                echo "Downloading latest CalDB version from main directory..."
+                wget "$MAIN_URL"
+              else
+                echo "Version ${CHANDRA_CALDB_VER} not found in main directory. Searching the old archives..."
+
+                OLD_BASE="https://cxc.cfa.harvard.edu/cdaftp/arcftp/caldb/old"
+                # Fetch the index of the old directory and grep for the removed_at_caldb folders
+                REMOVED_DIRS=$(curl -s "${OLD_BASE}/" | grep -o 'removed_at_caldb[0-9.]*')
+
+                DOWNLOAD_URL=""
+                for dir in $REMOVED_DIRS; do
+                  CANDIDATE_URL="${OLD_BASE}/${dir}/${TAR_FILE}"
+                  # Check if our specific tarball exists in this old folder
+                  if wget -q --spider "$CANDIDATE_URL"; then
+                    DOWNLOAD_URL="$CANDIDATE_URL"
+                    break
+                  fi
+                done
+
+                if [ -n "$DOWNLOAD_URL" ]; then
+                  echo "Found archived version. Downloading from ${DOWNLOAD_URL}..."
+                  wget "$DOWNLOAD_URL"
+                else
+                  echo "Error: CalDB version ${CHANDRA_CALDB_VER} could not be found in either location."
+                  exit 1
+                fi
+              fi
 
               # Unpack the archive into a specific directory
-              tar xzf caldb_${CHANDRA_CALDB_VER}_main.tar.gz -C chandra-caldb
-              rm caldb_${CHANDRA_CALDB_VER}_main.tar.gz
+              tar xzf "${TAR_FILE}" -C chandra-caldb
+              rm "${TAR_FILE}"
 
               # Make a version file
               echo "${CHANDRA_CALDB_VER}" > chandra-caldb/chandra-caldb.ver


### PR DESCRIPTION
Added new complexities (unfortunately necessary) to the 'Acquiring/validating Chandra CalDB' step of the cache-support-data job in CircleCI config.yml. The existing bash code would only suffice to pull the Chandra CalDB if it was the very latest version, otherwise it would throw a 404. This change should mean that the CalDB can be retrieved even if it is an older version.
