### PR TITLE
[Infrastructure]: Added mechanism to allow authors of notebooks to specify which calibration files they need

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,15 +306,25 @@ jobs:
 
             if [[ "$REQUIRED_CAL_SETS" == *",xmm-ccf,"* ]]; then
               echo "export RUN_XMM=true" >> "$BASH_ENV"
+            else
+              echo "export RUN_XMM=false" >> "$BASH_ENV"
             fi
 
             if [[ "$REQUIRED_CAL_SETS" == *",chandra,"* ]]; then
               echo "export RUN_CHANDRA=true" >> "$BASH_ENV"
+            else
+              echo "export RUN_CHANDRA=false" >> "$BASH_ENV"
             fi
 
             if [[ "$REQUIRED_CAL_SETS" == *",xspec-models,"* ]]; then
               echo "export RUN_XSPEC=true" >> "$BASH_ENV"
+            else
+              echo "export RUN_XSPEC=false" >> "$BASH_ENV"
             fi
+
+            echo $RUN_XMM
+            echo $RUN_CHANDRA
+            echo $RUN_XSPEC
 
       # Some missions (e.g. XMM, Chandra, eROSITA) require that their calibration files are available locally. We
       #  don't want to download them every single time, so we're going to cache them for future runs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ workflows:
           requires:
             - cache-support-data
           notebooks_to_build: << pipeline.parameters.notebooks_to_build >>
+          require_xmm_ccf: << pipeline.parameters.require_xmm_ccf >>
+          require_chandra: << pipeline.parameters.require_chandra >>
+          require_xspec_models: << pipeline.parameters.require_xspec_models >>
 
 
 # Here we define the different jobs that can be run in different CircleCI workflows.
@@ -56,6 +59,15 @@ jobs:
       notebooks_to_build:
         type: string
         default: ""
+      require_xmm_ccf:
+        type: boolean
+        default: False
+      require_chandra:
+        type: boolean
+        default: False
+      require_xspec_models:
+        type: boolean
+        default: False
     # We're using a docker container as a run environment - particularly the NASA Fornax
     #  high-energy image that we maintain as part of the Fornax initiative
     docker:
@@ -72,9 +84,6 @@ jobs:
 
     # What this job is actually going to do!
     steps:
-      - attach_workspace:
-          at: ~/workspace-data
-
       # Checking out the branch we're interested in
       - checkout
 
@@ -84,6 +93,22 @@ jobs:
       - run:
           name: Creating artifact storage directory
           command: mkdir -p artifacts
+
+      - run:
+          name: Preparing for calibration files and XSPEC models
+          command: |
+            # On the Fornax system, the support data directory (which we use to store calibration files, amongst
+            #  other things) is mounted from a different AWS system. In some versions of the Fornax-Hea images, that
+            #  can leave a broken symlink that we want to remove and replace with a real directory that we can
+            #  link our calibration files into.
+
+            # This step may become unnecessary, with some changes to the Fornax-Hea image that are still in dev, but
+            #  until then we're going to:
+            #   Check if there is a broken symlink
+            #   If there is, remove it and replace it with a real directory
+            [ -L "$SUPPORT_DATA_DIR" ] && ! [ -e "$SUPPORT_DATA_DIR" ] && rm "$SUPPORT_DATA_DIR"
+            # Then make a new support data directory, if it didn't already exist
+            mkdir -p $SUPPORT_DATA_DIR
 
       # 1. Load the most recent cache that matches the stub of the MyST notebook cache key
       # 2. Restore the XMM calibration file cache, saves us downloading it every time!
@@ -95,18 +120,46 @@ jobs:
           keys:
             - jupyter_ch-{{ .Branch }}-
             - jupyter_ch-
-#      - restore_cache:
-#          name: Restoring XMM CCF cache
-#          keys:
-#            - v2026-jan-xmm-ccf-
-#      - restore_cache:
-#          name: Restoring Chandra CalDB cache
-#          keys:
-#            - v2026-jan-chandra-ciao-caldb-
-#      - restore_cache:
-#          name: Restoring XSPEC models directory
-#          keys:
-#            - v2026-jan-xspec-models-
+
+      - when:
+          condition: << parameters.require_xmm_ccf >>
+          steps:
+            - restore_cache:
+                name: Restoring XMM CCF cache
+                keys:
+                  - v2026-jan-xmm-ccf-
+            - run:
+                name: Symlink XMM CCF directory
+                command: |
+                  # Linking the XMM CCFs to the location expected by the Fornax-Hea SAS conda environment
+                  ln -s $(pwd)/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
+
+      - when:
+          condition: << parameters.require_chandra >>
+          steps:
+            - restore_cache:
+                name: Restoring Chandra CalDB cache
+                keys:
+                  - v2026-jan-chandra-ciao-caldb-
+            - run:
+                name: Symlink Chandra CalDB directory
+                command: |
+                  # Linking the Chandra CalDB
+                  ln -s $(pwd)/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
+
+      - when:
+          condition: << parameters.require_xspec_models >>
+          steps:
+          - restore_cache:
+              name: Restoring XSPEC models directory
+              keys:
+                - v2026-jan-xspec-models-
+          - run:
+              name: Symlink XSPEC models directory
+              command: |
+                # Linking the XSPEC models directory
+                rm $ENV_DIR/heasoft/heasoft/spectral/modelData
+                ln -s $(pwd)/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
 
       # Any calibration files we need should have been restored from the caches, but we need to make sure that
       #  the mission-specific software can find those files.
@@ -130,27 +183,14 @@ jobs:
             mkdir -p $SUPPORT_DATA_DIR
 
             # Linking the XMM CCFs to the location expected by the Fornax-Hea SAS conda environment
-            #ln -s $(pwd)/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
+            ln -s $(pwd)/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
 
             # Linking the Chandra CalDB
-            #ln -s $(pwd)/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
+            ln -s $(pwd)/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
 
             # Linking the XSPEC models directory
-            #rm $ENV_DIR/heasoft/heasoft/spectral/modelData
-            #ln -s $(pwd)/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
-
-            # Define the base directory where the workspace was attached
-            WS_DATA_DIR="$HOME/workspace-data"
-
-            # Link the XMM CCFs using the absolute workspace path
-            ln -s $WS_DATA_DIR/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
-
-            # Link the Chandra CalDB
-            ln -s $WS_DATA_DIR/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
-
-            # Link the XSPEC models directory
             rm $ENV_DIR/heasoft/heasoft/spectral/modelData
-            ln -s $WS_DATA_DIR/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
+            ln -s $(pwd)/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
 
 #      - run:
 #          name: Installing extra dependencies
@@ -512,16 +552,3 @@ jobs:
                 #  properly in the second job, on a different runner/image
                 paths:
                   - xspec-data
-
-      # Ensure that the directories we want to persist to the workspace actually exist,
-      #  even if they are empty, otherwise the persist_to_workspace step will fail.
-      - run:
-          name: Ensuring calibration directories exist
-          command: mkdir -p xmm-ccf chandra-caldb xspec-data
-
-      - persist_to_workspace:
-          root: .
-          paths:
-            - xmm-ccf
-            - chandra-caldb
-            - xspec-data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ parameters:
 workflows:
   build-for-PR:
     jobs:
-      - cache-support-data
+      - cache-support-data:
           required_calibration_sets: << pipeline.parameters.required_calibration_sets >>
 
       - pr-build-docs:
@@ -65,7 +65,7 @@ jobs:
     # What this job is actually going to do!
     steps:
       - attach_workspace:
-          at: ~/
+          at: ~/workspace-data
 
       # Checking out the branch we're interested in
       - checkout
@@ -87,18 +87,18 @@ jobs:
           keys:
             - jupyter_ch-{{ .Branch }}-
             - jupyter_ch-
-      - restore_cache:
-          name: Restoring XMM CCF cache
-          keys:
-            - v2026-jan-xmm-ccf-
-      - restore_cache:
-          name: Restoring Chandra CalDB cache
-          keys:
-            - v2026-jan-chandra-ciao-caldb-
-      - restore_cache:
-          name: Restoring XSPEC models directory
-          keys:
-            - v2026-jan-xspec-models-
+#      - restore_cache:
+#          name: Restoring XMM CCF cache
+#          keys:
+#            - v2026-jan-xmm-ccf-
+#      - restore_cache:
+#          name: Restoring Chandra CalDB cache
+#          keys:
+#            - v2026-jan-chandra-ciao-caldb-
+#      - restore_cache:
+#          name: Restoring XSPEC models directory
+#          keys:
+#            - v2026-jan-xspec-models-
 
       # Any calibration files we need should have been restored from the caches, but we need to make sure that
       #  the mission-specific software can find those files.
@@ -122,14 +122,27 @@ jobs:
             mkdir -p $SUPPORT_DATA_DIR
 
             # Linking the XMM CCFs to the location expected by the Fornax-Hea SAS conda environment
-            ln -s $(pwd)/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
+            #ln -s $(pwd)/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
 
             # Linking the Chandra CalDB
-            ln -s $(pwd)/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
+            #ln -s $(pwd)/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
 
             # Linking the XSPEC models directory
+            #rm $ENV_DIR/heasoft/heasoft/spectral/modelData
+            #ln -s $(pwd)/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
+
+            # Define the base directory where the workspace was attached
+            WS_DATA_DIR="$HOME/workspace-data"
+
+            # Link the XMM CCFs using the absolute workspace path
+            ln -s $WS_DATA_DIR/xmm-ccf/ccf-files $SUPPORT_DATA_DIR/xmm_ccf
+
+            # Link the Chandra CalDB
+            ln -s $WS_DATA_DIR/chandra-caldb $SUPPORT_DATA_DIR/ciao-caldb-${CHANDRA_CALDB_VER}
+
+            # Link the XSPEC models directory
             rm $ENV_DIR/heasoft/heasoft/spectral/modelData
-            ln -s $(pwd)/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
+            ln -s $WS_DATA_DIR/xspec-data/modelData $ENV_DIR/heasoft/heasoft/spectral/modelData
 
 #      - run:
 #          name: Installing extra dependencies
@@ -496,4 +509,17 @@ jobs:
           # Making the path relative to the working directory, in the hope it will restore
           #  properly in the second job, on a different runner/image
           paths:
+            - xspec-data
+
+      # Ensure that the directories we want to persist to the workspace actually exist,
+      #  even if they are empty, otherwise the persist_to_workspace step will fail.
+      - run:
+          name: Ensuring calibration directories exist
+          command: mkdir -p xmm-ccf chandra-caldb xspec-data
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - xmm-ccf
+            - chandra-caldb
             - xspec-data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,13 @@ parameters:
     type: string
     default: ""
   require_xmm_ccf:
-    type: bool
+    type: boolean
     default: False
   require_chandra:
-    type: bool
+    type: boolean
     default: False
   require_xspec_models:
-    type: bool
+    type: boolean
     default: False
 
 # Defines the different workflows that we could run on CircleCI - a workflow is a combination of
@@ -282,13 +282,13 @@ jobs:
         type: string
         default: ""
       require_xmm_ccf:
-        type: bool
+        type: boolean
         default: False
       require_chandra:
-        type: bool
+        type: boolean
         default: False
       require_xspec_models:
-        type: bool
+        type: boolean
         default: False
 
     docker:
@@ -307,7 +307,7 @@ jobs:
       # We want to restore the caches that contain calibration files, so our download steps
       #  can check to see if they need to run at all.
       - when:
-          condition: << pipeline.parameters.require_xmm_ccf >>
+          condition: << parameters.require_xmm_ccf >>
           steps:
             - restore_cache:
                 name: Restoring XMM CCF cache
@@ -356,7 +356,7 @@ jobs:
 
 
       - when:
-          condition: << pipeline.parameters.require_chandra >>
+          condition: << parameters.require_chandra >>
           steps:
             - restore_cache:
                 name: Restoring Chandra CalDB cache
@@ -429,9 +429,8 @@ jobs:
                   - chandra-caldb
 
 
-
       - when:
-          condition: << pipeline.parameters.require_xspec_models >>
+          condition: << parameters.require_xspec_models >>
           steps:
             - restore_cache:
                 name: Restoring XSPEC models directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,15 @@ parameters:
   notebooks_to_build:
     type: string
     default: ""
-  required_calibration_sets:
-    type: string
-    default: ""
+  require_xmm_ccf:
+    type: bool
+    default: False
+  require_chandra:
+    type: bool
+    default: False
+  require_xspec_models:
+    type: bool
+    default: False
 
 # Defines the different workflows that we could run on CircleCI - a workflow is a combination of
 #  jobs that can be run sequentially or in parallel.
@@ -24,7 +30,9 @@ workflows:
   build-for-PR:
     jobs:
       - cache-support-data:
-          required_calibration_sets: << pipeline.parameters.required_calibration_sets >>
+          require_xmm_ccf: << pipeline.parameters.require_xmm_ccf >>
+          require_chandra: << pipeline.parameters.require_chandra >>
+          require_xspec_models: << pipeline.parameters.require_xspec_models >>
 
       - pr-build-docs:
           # Means the build job will wait for the cache-support-data job to complete before running
@@ -273,6 +281,15 @@ jobs:
       required_calibration_sets:
         type: string
         default: ""
+      require_xmm_ccf:
+        type: bool
+        default: False
+      require_chandra:
+        type: bool
+        default: False
+      require_xspec_models:
+        type: bool
+        default: False
 
     docker:
       - image: ghcr.io/nasa-fornax/fornax-images/fornax-slim:20260119_1436
@@ -282,244 +299,220 @@ jobs:
     #  YAML anchor to keep the values consistent across jobs
     <<: *version-env
     steps:
+      # Some missions (e.g. XMM, Chandra, eROSITA) need their calibration files to be available locally. We
+      #  don't want to download them every single time, so we're going to cache them for future runs.
+
       # Don't need a checkout step here, as we're just going to be downloading things.
 
       # We want to restore the caches that contain calibration files, so our download steps
       #  can check to see if they need to run at all.
-#      - restore_cache:
-#          name: Restoring XMM CCF cache
-#          keys:
-#            - v2026-jan-xmm-ccf-
-#      - restore_cache:
-#          name: Restoring Chandra CalDB cache
-#          keys:
-#            - v2026-jan-chandra-ciao-caldb-
-#      - restore_cache:
-#          name: Restoring XSPEC models directory
-#          keys:
-#            - v2026-jan-xspec-models-
+      - when:
+          condition: << pipeline.parameters.require_xmm_ccf >>
+          steps:
+            - restore_cache:
+                name: Restoring XMM CCF cache
+                keys:
+                  - v2026-jan-xmm-ccf-
 
-      - run:
-          name: Identify required calibration data and restore cached files
-          command: |
-            REQUIRED_CAL_SETS=",<< pipeline.parameters.required_calibration_sets >>,"
+            - run:
+                name: Acquiring/validating XMM-CCFs
+                no_output_timeout: 30m
+                command: |
+                  # We don't include rsync in the Fornax-Slim image, so unfortunately we'll have to install it now. The
+                  #  neatest way is to make a new conda environment that just contains rsync
+                  micromamba create -p ~/user-envs/rsync-env -y -c conda-forge python=3.12 rsync
 
-            if [[ "$REQUIRED_CAL_SETS" == *",xmm-ccf,"* ]]; then
-              echo "export RUN_XMM=true" >> "$BASH_ENV"
-            else
-              echo "export RUN_XMM=false" >> "$BASH_ENV"
-            fi
+                  # If we can't see the xmm_ccf directory, or the version file we generate doesn't contain the same
+                  #  version number as currently defined in the environment variable, we have to download the data
+                  if [ ! -d xmm-ccf ] || [[ ! "$(<"xmm-ccf/xmm-ccf.ver")" == "$CIRCLECI_XMM_CCF_VER" ]]; then
 
-            if [[ "$REQUIRED_CAL_SETS" == *",chandra,"* ]]; then
-              echo "export RUN_CHANDRA=true" >> "$BASH_ENV"
-            else
-              echo "export RUN_CHANDRA=false" >> "$BASH_ENV"
-            fi
+                    # Makes the xmm-ccf directory, if it doesn't already exist. This is a different approach to the
+                    #  what we do for the Chandra CalDB below, as rsync will update files if there are newer versions
+                    #  available, so we don't want to delete the directory.
+                    mkdir -p xmm-ccf/ccf-files
 
-            if [[ "$REQUIRED_CAL_SETS" == *",xspec-models,"* ]]; then
-              echo "export RUN_XSPEC=true" >> "$BASH_ENV"
-            else
-              echo "export RUN_XSPEC=false" >> "$BASH_ENV"
-            fi
+                    # We do delete the version file, if it exists, as if we get to this point then we are either downloading
+                    #  the data for the first time, or the version number has changed.
+                    [ -f xmm-ccf/xmm-ccf.ver ] && rm xmm-ccf/xmm-ccf.ver
 
-            echo $RUN_XMM
-            echo $RUN_CHANDRA
-            echo $RUN_XSPEC
+                    # Make a new version file - this goes a level up from the directory where the files will actually
+                    #  be stored (ccf-files), because the rsync process will delete the version file
+                    echo "${CIRCLECI_XMM_CCF_VER}" > xmm-ccf/xmm-ccf.ver
 
-      # Some missions (e.g. XMM, Chandra, eROSITA) require that their calibration files are available locally. We
-      #  don't want to download them every single time, so we're going to cache them for future runs.
-      - run:
-          name: Acquiring/validating XMM-CCFs
-          no_output_timeout: 30m
-          command: |
-            # Check if we need to have the XMM CCFs available for the notebooks that are due to be built
-            [ "$RUN_XMM" = "true" ] || exit 0
-
-            echo "Attempting to restore the XMM CCF cache"
-            circleci-agent cache restore --key "v2026-jan-xmm-ccf-"
-
-            # We don't include rsync in the Fornax-Slim image, so unfortunately we'll have to install it now. The
-            #  neatest way is to make a new conda environment that just contains rsync
-            micromamba create -p ~/user-envs/rsync-env -y -c conda-forge python=3.12 rsync
-
-            # If we can't see the xmm_ccf directory, or the version file we generate doesn't contain the same
-            #  version number as currently defined in the environment variable, we have to download the data
-            if [ ! -d xmm-ccf ] || [[ ! "$(<"xmm-ccf/xmm-ccf.ver")" == "$CIRCLECI_XMM_CCF_VER" ]]; then
-
-              # Makes the xmm-ccf directory, if it doesn't already exist. This is a different approach to the
-              #  what we do for the Chandra CalDB below, as rsync will update files if there are newer versions
-              #  available, so we don't want to delete the directory.
-              mkdir -p xmm-ccf/ccf-files
-
-              # We do delete the version file, if it exists, as if we get to this point then we are either downloading
-              #  the data for the first time, or the version number has changed.
-              [ -f xmm-ccf/xmm-ccf.ver ] && rm xmm-ccf/xmm-ccf.ver
-
-              # Make a new version file - this goes a level up from the directory where the files will actually
-              #  be stored (ccf-files), because the rsync process will delete the version file
-              echo "${CIRCLECI_XMM_CCF_VER}" > xmm-ccf/xmm-ccf.ver
-
-              # Actually rsync the calibration files
-              micromamba run -p ~/user-envs/rsync-env rsync -v -a --delete --delete-after --force --include='*.CCF' --exclude='*/' sasdev-xmm.esac.esa.int::XMM_VALID_CCF xmm-ccf/ccf-files
-            fi
-
-      # Cache the XMM CCFs so we don't have to download them every time - we checksum the version file
-      #  we generated because CircleCI doesn't allow you to use environment variables in cache keys. This
-      #  is a good way round that
-      # (https://devops.stackexchange.com/questions/9147/how-to-get-other-than-no-value-when-interpolating-environment-some-var)
-      - save_cache:
-          key: v2026-jan-xmm-ccf-cs{{ checksum "xmm-ccf/xmm-ccf.ver" }}
-          # Making the path relative to the working directory, in the hope it will restore
-          #  properly in the second job, on a different runner/image
-          paths:
-            - xmm-ccf
-
-      # We also download the Chandra CalDB
-      - run:
-          name: Acquiring/validating Chandra CalDB
-          no_output_timeout: 30m
-          command: |
-            # Check if we need to have the Chandra CalDB available for the notebooks that are due to be built
-            [ "$RUN_CHANDRA" = "true" ] || exit 0
-
-            echo "Attempting to restore the Chandra CalDB cache"
-            circleci-agent cache restore --key "v2026-jan-chandra-ciao-caldb-"
-
-            # If the chandra-caldb directory doesn't exist, or it does but the version file doesn't contain the
-            #  same version number as currently defined in the environment variable, or the version file doesn't
-            #  exist at all, we have to download the data,
-            if [ ! -d chandra-caldb ] || [ ! -f chandra-caldb/chandra-caldb.ver ] || [[ ! "$(<"chandra-caldb/chandra-caldb.ver")" == "$CHANDRA_CALDB_VER" ]]; then
-
-              # Make a directory (this helps avoid CircleCI's restrictions on
-              #  dynamic cache key/path names) - delete an existing directory if it exists
-              [ -d chandra-caldb ] && rm -rf chandra-caldb
-              mkdir -p chandra-caldb
-
-              # Define file and URLs
-              TAR_FILE="caldb_${CHANDRA_CALDB_VER}_main.tar.gz"
-              MAIN_URL="https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB/tars/${TAR_FILE}"
-
-              # Check if the requested version is the latest one stored in the main directory
-              if wget -q --spider "$MAIN_URL"; then
-                echo "Downloading latest CalDB version from main directory..."
-                wget "$MAIN_URL"
-              else
-                echo "Version ${CHANDRA_CALDB_VER} not found in main directory. Searching the old archives..."
-
-                OLD_BASE="https://cxc.cfa.harvard.edu/cdaftp/arcftp/caldb/old"
-                # Fetch the index of the old directory and grep for the removed_at_caldb folders
-                REMOVED_DIRS=$(curl -s "${OLD_BASE}/" | grep -o 'removed_at_caldb[0-9.]*')
-
-                DOWNLOAD_URL=""
-                for dir in $REMOVED_DIRS; do
-                  CANDIDATE_URL="${OLD_BASE}/${dir}/${TAR_FILE}"
-                  # Check if our specific tarball exists in this old folder
-                  if wget -q --spider "$CANDIDATE_URL"; then
-                    DOWNLOAD_URL="$CANDIDATE_URL"
-                    break
+                    # Actually rsync the calibration files
+                    micromamba run -p ~/user-envs/rsync-env rsync -v -a --delete --delete-after --force --include='*.CCF' --exclude='*/' sasdev-xmm.esac.esa.int::XMM_VALID_CCF xmm-ccf/ccf-files
                   fi
-                done
 
-                if [ -n "$DOWNLOAD_URL" ]; then
-                  echo "Found archived version. Downloading from ${DOWNLOAD_URL}..."
-                  wget "$DOWNLOAD_URL"
-                else
-                  echo "Error: CalDB version ${CHANDRA_CALDB_VER} could not be found in either location."
-                  exit 1
-                fi
-              fi
-
-              # Unpack the archive into a specific directory
-              tar xzf "${TAR_FILE}" -C chandra-caldb
-              rm "${TAR_FILE}"
-
-              # Make a version file
-              echo "${CHANDRA_CALDB_VER}" > chandra-caldb/chandra-caldb.ver
-            fi
-
-      # Also add the Chandra CalDB to the cache
-      - save_cache:
-          key: v2026-jan-chandra-ciao-caldb-cs{{ checksum "chandra-caldb/chandra-caldb.ver" }}
-          # Making the path relative to the working directory, in the hope it will restore
-          #  properly in the second job, on a different runner/image
-          paths:
-            - chandra-caldb
-
-      # The XSPEC model files directory is large and isn't included in the Fornax-Hea image. Some notebooks
-      #  will need those files to be present, so we download and cache them here.
-      - run:
-          name: Acquiring XSPEC model files
-          no_output_timeout: 30m
-          command: |
-
-            # Check if we need to have the XSPEC models available for the notebooks that are due to be built
-            [ "$RUN_XSPEC" = "true" ] || exit 0
-
-            echo "Attempting to restore the XSPEC-models cache"
-            circleci-agent cache restore --key "v2026-jan-xspec-models-"
-
-            # Make sure that jq is installed
-            micromamba -p ~/user-envs/rsync-env install -y -c conda-forge jq
+            # Cache the XMM CCFs so we don't have to download them every time - we checksum the version file
+            #  we generated because CircleCI doesn't allow you to use environment variables in cache keys. This
+            #  is a good way round that
+            # (https://devops.stackexchange.com/questions/9147/how-to-get-other-than-no-value-when-interpolating-environment-some-var)
+            - save_cache:
+                key: v2026-jan-xmm-ccf-cs{{ checksum "xmm-ccf/xmm-ccf.ver" }}
+                # Making the path relative to the working directory, in the hope it will restore
+                #  properly in the second job, on a different runner/image
+                paths:
+                  - xmm-ccf
 
 
-            CONDA_OUTPUT=$(micromamba -p ~/user-envs/rsync-env install -c https://heasarc.gsfc.nasa.gov/FTP/software/conda/ --dry-run --json xspec-data=$XSPEC_DATA_VER 2>/dev/null)
+      - when:
+          condition: << pipeline.parameters.require_chandra >>
+          steps:
+            - restore_cache:
+                name: Restoring Chandra CalDB cache
+                keys:
+                  - v2026-jan-chandra-ciao-caldb-
 
-            XSPEC_DATA_LINK=$(echo "$CONDA_OUTPUT" | micromamba -p ~/user-envs/rsync-env run jq -r '.actions.LINK[] | select(.name == "xspec-data") | .url')
+            # We also download the Chandra CalDB
+            - run:
+                name: Acquiring/validating Chandra CalDB
+                no_output_timeout: 30m
+                command: |
+                  # If the chandra-caldb directory doesn't exist, or it does but the version file doesn't contain the
+                  #  same version number as currently defined in the environment variable, or the version file doesn't
+                  #  exist at all, we have to download the data,
+                  if [ ! -d chandra-caldb ] || [ ! -f chandra-caldb/chandra-caldb.ver ] || [[ ! "$(<"chandra-caldb/chandra-caldb.ver")" == "$CHANDRA_CALDB_VER" ]]; then
 
-            # Show the XSPEC data version and link
-            echo $XSPEC_DATA_VER
-            echo $XSPEC_DATA_LINK
+                    # Make a directory (this helps avoid CircleCI's restrictions on
+                    #  dynamic cache key/path names) - delete an existing directory if it exists
+                    [ -d chandra-caldb ] && rm -rf chandra-caldb
+                    mkdir -p chandra-caldb
 
-            # If the xspec-data directory doesn't exist, or it does but the version file doesn't contain the same
-            #  version as the one we just determined from the conda solver, we have to download the data.
-            if [ ! -d xspec-data ] || [ ! -f xspec-data/xspec-data.ver ] || [[ ! "$(<"xspec-data/xspec-data.ver")" == "$XSPEC_DATA_VER" ]]; then
+                    # Define file and URLs
+                    TAR_FILE="caldb_${CHANDRA_CALDB_VER}_main.tar.gz"
+                    MAIN_URL="https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB/tars/${TAR_FILE}"
 
-              # Make a directory (this helps avoid CircleCI's restrictions on
-              #  dynamical cache key/path names) - delete an existing directory if it exists
-              [ -d xspec-data ] && rm -rf xspec-data
-              mkdir -p xspec-data
+                    # Check if the requested version is the latest one stored in the main directory
+                    if wget -q --spider "$MAIN_URL"; then
+                      echo "Downloading latest CalDB version from main directory..."
+                      wget "$MAIN_URL"
+                    else
+                      echo "Version ${CHANDRA_CALDB_VER} not found in main directory. Searching the old archives..."
 
-              # Also make a temporary working directory
-              mkdir -p xspec-data-work-dir
+                      OLD_BASE="https://cxc.cfa.harvard.edu/cdaftp/arcftp/caldb/old"
+                      # Fetch the index of the old directory and grep for the removed_at_caldb folders
+                      REMOVED_DIRS=$(curl -s "${OLD_BASE}/" | grep -o 'removed_at_caldb[0-9.]*')
 
-              # Store current WD and move to the temporary working directory
-              PRE_XSPEC_DATA_WD=$(pwd)
-              cd xspec-data-work-dir
+                      DOWNLOAD_URL=""
+                      for dir in $REMOVED_DIRS; do
+                        CANDIDATE_URL="${OLD_BASE}/${dir}/${TAR_FILE}"
+                        # Check if our specific tarball exists in this old folder
+                        if wget -q --spider "$CANDIDATE_URL"; then
+                          DOWNLOAD_URL="$CANDIDATE_URL"
+                          break
+                        fi
+                      done
 
-              # Download the XSPEC model files
-              wget $XSPEC_DATA_LINK -O xspec-data.zip
+                      if [ -n "$DOWNLOAD_URL" ]; then
+                        echo "Found archived version. Downloading from ${DOWNLOAD_URL}..."
+                        wget "$DOWNLOAD_URL"
+                      else
+                        echo "Error: CalDB version ${CHANDRA_CALDB_VER} could not be found in either location."
+                        exit 1
+                      fi
+                    fi
 
-              # Install unzip, as the *.conda file we just downloaded is a zip archive
-              micromamba -p ~/user-envs/rsync-env install -y -c conda-forge unzip zstd
-              # Unzip the archive
-              micromamba -p ~/user-envs/rsync-env run unzip xspec-data.zip
+                    # Unpack the archive into a specific directory
+                    tar xzf "${TAR_FILE}" -C chandra-caldb
+                    rm "${TAR_FILE}"
 
-              # Untar and decompress the part of the *.conda package file that contains the package contents, as
-              #  opposed to the metadata.
-              micromamba -p ~/user-envs/rsync-env run tar --use-compress-program=unzstd -xvf pkg-xspec-data-*.tar.zst
+                    # Make a version file
+                    echo "${CHANDRA_CALDB_VER}" > chandra-caldb/chandra-caldb.ver
+                  fi
 
-              # Move the extracted files into the xspec-data directory, going up a level
-              #  because we cd-ed into the temporary working directory
-              mv heasoft/spectral/modelData ../xspec-data/
-              # Make a version file
-              echo "${XSPEC_DATA_VER}" > ../xspec-data/xspec-data.ver
+            # Also add the Chandra CalDB to the cache
+            - save_cache:
+                key: v2026-jan-chandra-ciao-caldb-cs{{ checksum "chandra-caldb/chandra-caldb.ver" }}
+                # Making the path relative to the working directory, in the hope it will restore
+                #  properly in the second job, on a different runner/image
+                paths:
+                  - chandra-caldb
 
-              # Move back to the original working directory
-              cd $PRE_XSPEC_DATA_WD
 
-              # Delete the temporary working directory
-              rm -rf xspec-data-work-dir
 
-            fi
+      - when:
+          condition: << pipeline.parameters.require_xspec_models >>
+          steps:
+            - restore_cache:
+                name: Restoring XSPEC models directory
+                keys:
+                  - v2026-jan-xspec-models-
 
-      # Store the XSPEC model files in a cache. They are big enough that we definitely don't want
-      #  to be downloading them repeatedly
-      - save_cache:
-          key: v2026-jan-xspec-models-cs{{ checksum "xspec-data/xspec-data.ver" }}
-          # Making the path relative to the working directory, in the hope it will restore
-          #  properly in the second job, on a different runner/image
-          paths:
-            - xspec-data
+            # The XSPEC model files directory is large and isn't included in the Fornax-Hea image. Some notebooks
+            #  will need those files to be present, so we download and cache them here.
+            - run:
+                name: Acquiring XSPEC model files
+                no_output_timeout: 30m
+                command: |
+
+                  # Check if we need to have the XSPEC models available for the notebooks that are due to be built
+                  [ "$RUN_XSPEC" = "true" ] || exit 0
+
+                  echo "Attempting to restore the XSPEC-models cache"
+                  circleci-agent cache restore --key "v2026-jan-xspec-models-"
+
+                  # Make sure that jq is installed
+                  micromamba -p ~/user-envs/rsync-env install -y -c conda-forge jq
+
+
+                  CONDA_OUTPUT=$(micromamba -p ~/user-envs/rsync-env install -c https://heasarc.gsfc.nasa.gov/FTP/software/conda/ --dry-run --json xspec-data=$XSPEC_DATA_VER 2>/dev/null)
+
+                  XSPEC_DATA_LINK=$(echo "$CONDA_OUTPUT" | micromamba -p ~/user-envs/rsync-env run jq -r '.actions.LINK[] | select(.name == "xspec-data") | .url')
+
+                  # Show the XSPEC data version and link
+                  echo $XSPEC_DATA_VER
+                  echo $XSPEC_DATA_LINK
+
+                  # If the xspec-data directory doesn't exist, or it does but the version file doesn't contain the same
+                  #  version as the one we just determined from the conda solver, we have to download the data.
+                  if [ ! -d xspec-data ] || [ ! -f xspec-data/xspec-data.ver ] || [[ ! "$(<"xspec-data/xspec-data.ver")" == "$XSPEC_DATA_VER" ]]; then
+
+                    # Make a directory (this helps avoid CircleCI's restrictions on
+                    #  dynamical cache key/path names) - delete an existing directory if it exists
+                    [ -d xspec-data ] && rm -rf xspec-data
+                    mkdir -p xspec-data
+
+                    # Also make a temporary working directory
+                    mkdir -p xspec-data-work-dir
+
+                    # Store current WD and move to the temporary working directory
+                    PRE_XSPEC_DATA_WD=$(pwd)
+                    cd xspec-data-work-dir
+
+                    # Download the XSPEC model files
+                    wget $XSPEC_DATA_LINK -O xspec-data.zip
+
+                    # Install unzip, as the *.conda file we just downloaded is a zip archive
+                    micromamba -p ~/user-envs/rsync-env install -y -c conda-forge unzip zstd
+                    # Unzip the archive
+                    micromamba -p ~/user-envs/rsync-env run unzip xspec-data.zip
+
+                    # Untar and decompress the part of the *.conda package file that contains the package contents, as
+                    #  opposed to the metadata.
+                    micromamba -p ~/user-envs/rsync-env run tar --use-compress-program=unzstd -xvf pkg-xspec-data-*.tar.zst
+
+                    # Move the extracted files into the xspec-data directory, going up a level
+                    #  because we cd-ed into the temporary working directory
+                    mv heasoft/spectral/modelData ../xspec-data/
+                    # Make a version file
+                    echo "${XSPEC_DATA_VER}" > ../xspec-data/xspec-data.ver
+
+                    # Move back to the original working directory
+                    cd $PRE_XSPEC_DATA_WD
+
+                    # Delete the temporary working directory
+                    rm -rf xspec-data-work-dir
+
+                  fi
+
+            # Store the XSPEC model files in a cache. They are big enough that we definitely don't want
+            #  to be downloading them repeatedly
+            - save_cache:
+                key: v2026-jan-xspec-models-cs{{ checksum "xspec-data/xspec-data.ver" }}
+                # Making the path relative to the working directory, in the hope it will restore
+                #  properly in the second job, on a different runner/image
+                paths:
+                  - xspec-data
 
       # Ensure that the directories we want to persist to the workspace actually exist,
       #  even if they are empty, otherwise the persist_to_workspace step will fail.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,12 @@ version: 2.1
 
 # The parameters that can be passed when calling CircleCI through the API.
 #  + notebooks_to_build: A comma-separated list of relative notebook paths to files that should be built. Every other notebook will be ignored.
+#  + required_calibration_sets: A comma-separated list of calibration data sets that need to be loaded (thus downloaded/cached) for the build(s).
 parameters:
   notebooks_to_build:
+    type: string
+    default: ""
+  required_calibration_sets:
     type: string
     default: ""
 
@@ -20,6 +24,8 @@ workflows:
   build-for-PR:
     jobs:
       - cache-support-data
+          required_calibration_sets: << pipeline.parameters.required_calibration_sets >>
+
       - pr-build-docs:
           # Means the build job will wait for the cache-support-data job to complete before running
           requires:
@@ -246,6 +252,15 @@ jobs:
   #  so that they only need to be downloaded if the cache is wiped (happens after a few weeks I think), or
   #  the version number of the files changes.
   cache-support-data:
+    # Allows parameters to be passed into the job when
+    #  it is triggered through the API.
+    # The required_calibration_sets parameter names calibration data sets that need to
+    #  be loaded (thus downloaded/cached) for the build(s). Default value of "" means
+    parameters:
+      required_calibration_sets:
+        type: string
+        default: ""
+
     docker:
       - image: ghcr.io/nasa-fornax/fornax-images/fornax-slim:20260119_1436
     # We use the small resource class (1 core, 2GB RAM) as this job should just download files to disk
@@ -258,44 +273,35 @@ jobs:
 
       # We want to restore the caches that contain calibration files, so our download steps
       #  can check to see if they need to run at all.
-      - restore_cache:
-          name: Restoring XMM CCF cache
-          keys:
-            - v2026-jan-xmm-ccf-
-      - restore_cache:
-          name: Restoring Chandra CalDB cache
-          keys:
-            - v2026-jan-chandra-ciao-caldb-
-      - restore_cache:
-          name: Restoring XSPEC models directory
-          keys:
-            - v2026-jan-xspec-models-
-
-      # Restore micromamba installation from cache if available
 #      - restore_cache:
-#          name: Restoring micromamba installation
+#          name: Restoring XMM CCF cache
 #          keys:
-#            - micromamba-
+#            - v2026-jan-xmm-ccf-
+#      - restore_cache:
+#          name: Restoring Chandra CalDB cache
+#          keys:
+#            - v2026-jan-chandra-ciao-caldb-
+#      - restore_cache:
+#          name: Restoring XSPEC models directory
+#          keys:
+#            - v2026-jan-xspec-models-
 
-      # Install micromamba if not restored from cache. I'm afraid I'm not
-      #  going to be picky about the version, as we only need a very small
-      #  core feature that isn't that likely to change
-#      - run:
-#          name: Installing micromamba
-#          command: |
-#            if [ ! -f $HOME/micromamba/bin/micromamba ]; then
-#              curl -L micro.mamba.pm/install.sh | bash -s -- -b -p $HOME/micromamba
-#            fi
-#
-#            # Source bashrc to activate micromamba in current shell
-#            . $HOME/.bashrc
-#            micromamba --version
+      - run:
+          name: Identify required calibration data and restore cached files
+          command: |
+            REQUIRED_CAL_SETS=",<< pipeline.parameters.required_calibration_sets >>,"
 
-      # Cache micromamba installation for future runs
-#      - save_cache:
-#          key: micromamba-v1
-#          paths:
-#            - micromamba
+            if [[ "$REQUIRED_CAL_SETS" == *",xmm-ccf,"* ]]; then
+              echo "export RUN_XMM=true" >> "$BASH_ENV"
+            fi
+
+            if [[ "$REQUIRED_CAL_SETS" == *",chandra,"* ]]; then
+              echo "export RUN_CHANDRA=true" >> "$BASH_ENV"
+            fi
+
+            if [[ "$REQUIRED_CAL_SETS" == *",xspec-models,"* ]]; then
+              echo "export RUN_XSPEC=true" >> "$BASH_ENV"
+            fi
 
       # Some missions (e.g. XMM, Chandra, eROSITA) require that their calibration files are available locally. We
       #  don't want to download them every single time, so we're going to cache them for future runs.
@@ -303,6 +309,12 @@ jobs:
           name: Acquiring/validating XMM-CCFs
           no_output_timeout: 30m
           command: |
+            # Check if we need to have the XMM CCFs available for the notebooks that are due to be built
+            [ "$RUN_XMM" = "true" ] || exit 0
+
+            echo "Attempting to restore the XMM CCF cache"
+            circleci-agent cache restore --key "v2026-jan-xmm-ccf-"
+
             # We don't include rsync in the Fornax-Slim image, so unfortunately we'll have to install it now. The
             #  neatest way is to make a new conda environment that just contains rsync
             micromamba create -p ~/user-envs/rsync-env -y -c conda-forge python=3.12 rsync
@@ -344,6 +356,12 @@ jobs:
           name: Acquiring/validating Chandra CalDB
           no_output_timeout: 30m
           command: |
+            # Check if we need to have the Chandra CalDB available for the notebooks that are due to be built
+            [ "$RUN_CHANDRA" = "true" ] || exit 0
+
+            echo "Attempting to restore the Chandra CalDB cache"
+            circleci-agent cache restore --key "v2026-jan-chandra-ciao-caldb-"
+
             # If the chandra-caldb directory doesn't exist, or it does but the version file doesn't contain the
             #  same version number as currently defined in the environment variable, or the version file doesn't
             #  exist at all, we have to download the data,
@@ -410,6 +428,13 @@ jobs:
           name: Acquiring XSPEC model files
           no_output_timeout: 30m
           command: |
+
+            # Check if we need to have the XSPEC models available for the notebooks that are due to be built
+            [ "$RUN_XSPEC" = "true" ] || exit 0
+
+            echo "Attempting to restore the XSPEC-models cache"
+            circleci-agent cache restore --key "v2026-jan-xspec-models-"
+
             # Make sure that jq is installed
             micromamba -p ~/user-envs/rsync-env install -y -c conda-forge jq
 

--- a/.github/workflows/collate-cal-files.py
+++ b/.github/workflows/collate-cal-files.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
             # Then this information will be shown to the notebook author so they can
             #  diagnose what went wrong. We don't prettify the output, as it doesn't
             #  really need to be pretty
-            gha_outo.write(str(bad_meta_spec) + "\n")
+            gha_outo.write(f"bad_cal_spec={str(bad_meta_spec)}\n")
         else:
             # We always write the 'any_bad_cal_spec entry, so the next GHA step can check to
             #  see if it's True before having to parse the actual information about what went wrong

--- a/.github/workflows/collate-cal-files.py
+++ b/.github/workflows/collate-cal-files.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     # Iterate through the notebooks that we'll be executing
     for cur_nb in rel_nbs:
         # Define the full path
-        cur_nb_path = os.path.join(cur_workspace, cur_nb)
+        cur_nb_path = os.path.join(cur_workspace, "tutorials", cur_nb)
 
         # Load the file and parse with Jupytext
         with open(cur_nb_path, 'r') as md_read:

--- a/.github/workflows/collate-cal-files.py
+++ b/.github/workflows/collate-cal-files.py
@@ -72,10 +72,10 @@ if __name__ == '__main__':
     cur_gha_out = os.environ["GITHUB_OUTPUT"]
 
     with open(cur_gha_out, "a") as gha_outo:
-        # This writes the names of the selected calibration sets to a file that will be
-        #  read and accessible in the next GHA step (which will be the part where
-        #  the CircleCI workflow is actually triggered)
-        gha_outo.write(f"required_cal_sets={",".join(all_cal_files)}\n")
+        # This writes one variable per calibration set, describing whether that calibration
+        #  set has to be loaded or not
+        for cal_name in allowed_cal_names:
+            gha_outo.write(f"require_{cal_name}={cal_name in all_cal_files}\n")
 
         # In this case, some illegal entry was identified in one or more of the notebooks
         #  specified for building, and we need to make sure that information is available

--- a/.github/workflows/collate-cal-files.py
+++ b/.github/workflows/collate-cal-files.py
@@ -1,0 +1,93 @@
+import jupytext
+import os
+
+if __name__ == '__main__':
+
+    # The location of the checked out HEASARC-tutorials repository
+    cur_workspace = os.environ['GITHUB_WORKSPACE']
+
+    # Location of the template notebook - it contains the names of all current calibration
+    #  data sets that the execution workflow can download and cache
+    cur_nb_temp_path = os.path.join(cur_workspace, 'notebook-templates', 'notebook_template.md')
+    # Load the file and extract the allowed names from the metadata (i.e. front-matter)
+    with open(cur_nb_temp_path, 'r') as md_read:
+        cur_nb_temp_jupy = jupytext.reads(md_read.read())
+        allowed_cal_names = list(cur_nb_temp_jupy.metadata['execution']['cal-files'].keys())
+
+    # Paths to notebooks that will be executed in this GHA run, relative to the
+    #  top-level repository directory. This could either be a single notebook, or a
+    #  set of notebooks separated by ','
+    rel_nbs = os.environ['NOTEBOOKS_TO_BUILD']
+    # Make sure that the rel_nbs variable is a Python list of notebooks (will become
+    #  a one-element list if there is only one notebook).
+    rel_nbs = rel_nbs.split(',')
+
+    # The bucket we'll add all the notebook-author-specified calibration sets to, there may well be
+    #  duplicates by the end, but we'll take care of that.
+    all_cal_files = []
+    # Then a dictionary in which we can record any illegal entries in the execution: cal-files: section
+    #  of the front matter. That will get passed back out to the GHA, which will then raise an error and
+    #  fail the action
+    bad_meta_spec = {}
+
+    # Iterate through the notebooks that we'll be executing
+    for cur_nb in rel_nbs:
+        # Define the full path
+        cur_nb_path = os.path.join(cur_workspace, cur_nb)
+
+        # Load the file and parse with Jupytext
+        with open(cur_nb_path, 'r') as md_read:
+            cur_nb_jupy = jupytext.reads(md_read.read())
+
+        # From here, accessing the front-matter information is very easy, as it has
+        #  already been stored in the 'metadata' property.
+        # We do check that there is an entry for 'cal-files' - this will become part of
+        #  the HEASARC-tutorials MD standard/format, but best to be flexible regarding
+        #  whether the information is there or not for now.
+        # If no information is available, we assume all calibration sets are required
+        if 'execution' not in cur_nb_jupy.metadata or 'cal-files' not in cur_nb_jupy.metadata['execution']:
+            all_cal_files += allowed_cal_names
+            continue
+        elif len(bad_cal := [cur_cal_name for cur_cal_name in cur_nb_jupy.metadata['execution']['cal-files'].keys() if cur_cal_name not in allowed_cal_names]) != 0:
+            bad_meta_spec[cur_nb] = bad_cal
+            continue
+        elif len(bad_cal_val := [f"{cur_cal_name} ({cur_cal_val})" for cur_cal_name, cur_cal_val in cur_nb_jupy.metadata['execution']['cal-files'].items() if not isinstance(cur_cal_val, bool)]) != 0:
+            bad_meta_spec[cur_nb] = bad_cal_val
+            continue
+
+        # If we get here, then calibration set information WAS included in the notebook front-matter, and as far as
+        #  we can tell, it was formatted correctly. All we have left to do is sweep through the cal-files and see
+        #  which ones were marked as True
+        cur_sel_cal = [cur_cal_name for cur_cal_name, cur_cal_val in cur_nb_jupy.metadata['execution']['cal-files'].items() if cur_cal_val]
+        # Put the selected calibration sets in the bucket we're using for every notebook that has
+        #  been marked for building using the CircleCI workflow.
+        all_cal_files += cur_sel_cal
+
+    # At this point we've run through all the notebooks, so we can find the unique entries in
+    #  the all_cal_files variable we populated in the loop, and those are then the calibration
+    #  data sets that we need to tell the CircleCI workflow to load.
+    all_cal_files = list(set(all_cal_files))
+
+    # Now we write to the GitHub actions output file for the current step
+    cur_gha_out = os.environ["GITHUB_OUTPUT"]
+
+    with open(cur_gha_out, "a") as gha_outo:
+        # This writes the names of the selected calibration sets to a file that will be
+        #  read and accessible in the next GHA step (which will be the part where
+        #  the CircleCI workflow is actually triggered)
+        gha_outo.write(f"required_cal_sets={",".join(all_cal_files)}\n")
+
+        # In this case, some illegal entry was identified in one or more of the notebooks
+        #  specified for building, and we need to make sure that information is available
+        #  to the next step so it can error out
+        if len(bad_meta_spec) != 0:
+            # Tells the next step right off the bat that something is wrong
+            gha_outo.write("any_bad_cal_spec=true\n")
+            # Then this information will be shown to the notebook author so they can
+            #  diagnose what went wrong. We don't prettify the output, as it doesn't
+            #  really need to be pretty
+            gha_outo.write(str(bad_meta_spec) + "\n")
+        else:
+            # We always write the 'any_bad_cal_spec entry, so the next GHA step can check to
+            #  see if it's True before having to parse the actual information about what went wrong
+            gha_outo.write("any_bad_cal_spec=false\n")

--- a/.github/workflows/collate-cal-files.py
+++ b/.github/workflows/collate-cal-files.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
         # This writes one variable per calibration set, describing whether that calibration
         #  set has to be loaded or not
         for cal_name in allowed_cal_names:
-            gha_outo.write(f"require_{cal_name}={cal_name in all_cal_files}\n")
+            gha_outo.write(f"require_{cal_name}={"true" if cal_name in all_cal_files else "false"}\n")
 
         # In this case, some illegal entry was identified in one or more of the notebooks
         #  specified for building, and we need to make sure that information is available

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -129,7 +129,7 @@ jobs:
         if: success() && steps.which_notebooks_to_build.outputs.notebooks_to_build != ''
         run: |
           python -m pip install --upgrade pip
-          pip install -r jupytext
+          pip install jupytext
 
       - name: Determine which calibration datasets are required
         id: which_cal_data

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -166,6 +166,7 @@ jobs:
         run: |
           echo "pre-commit.ci checks passed on branch ${TARGET_BRANCH}. Triggering CircleCI."
           echo "Notebooks to build: ${NOTEBOOKS_TO_BUILD}"
+          echo "Required calibration datasets: ${REQUIRED_CALIBRATION_SETS}"
 
           # Post request to CircleCI API v2 to trigger a new pipeline
           # We pass arguments to the pipeline via the 'parameters' field, which

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -183,7 +183,7 @@ jobs:
               "parameters": {
                 "notebooks_to_build": "'"${NOTEBOOKS_TO_BUILD}"'",
                 "require_xmm_ccf": "'"${REQUIRE_XMM_CCF}"'",
-                "require_chandra": "'"${REQUIRE_CHANDRA}"'",
-                "require_xspec_models": "'"${REQUIRE_XSPEC_MODELS}"'"
+                "require_chandra": ${REQUIRE_CHANDRA},
+                "require_xspec_models": ${REQUIRE_XSPEC_MODELS}
               }
              }'

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -161,7 +161,9 @@ jobs:
           PROJECT_SLUG: 'circleci/LdzbTUR6aexSM6vJCVrZk5/GRoaAeYuJNgCdifZviG612'
           CHECKOUT_REPO: 'HEASARC/heasarc-tutorials'
           NOTEBOOKS_TO_BUILD: ${{ steps.which_notebooks_to_build.outputs.notebooks_to_build }}
-          REQUIRED_CALIBRATION_SETS: ${{ steps.which_cal_data.outputs.required_cal_sets }}
+          REQUIRE_XMM_CCF: ${{ steps.which_cal_data.outputs.require_xmm-ccf }}
+          REQUIRE_CHANDRA: ${{ steps.which_cal_data.outputs.require_chandra }}
+          REQUIRE_XSPEC_MODELS: ${{ steps.which_cal_data.outputs.require_xspec-models }}
 
         run: |
           echo "pre-commit.ci checks passed on branch ${TARGET_BRANCH}. Triggering CircleCI."
@@ -181,6 +183,8 @@ jobs:
               "checkout": {"branch": "'"${TARGET_BRANCH}"'"},
               "parameters": {
                 "notebooks_to_build": "'"${NOTEBOOKS_TO_BUILD}"'",
-                "required_calibration_sets": "'"${REQUIRED_CALIBRATION_SETS}"'"
+                "require_xmm_ccf": "'"${REQUIRE_XMM_CCF}"'",
+                "require_chandra": "'"${REQUIRE_CHANDRA}"'",
+                "require_xspec_models": "'"${REQUIRE_XSPEC_MODELS}"'"
               }
              }'

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -182,8 +182,8 @@ jobs:
               "checkout": {"branch": "'"${TARGET_BRANCH}"'"},
               "parameters": {
                 "notebooks_to_build": "'"${NOTEBOOKS_TO_BUILD}"'",
-                "require_xmm_ccf": "'"${REQUIRE_XMM_CCF}"'",
-                "require_chandra": ${REQUIRE_CHANDRA},
-                "require_xspec_models": ${REQUIRE_XSPEC_MODELS}
+                "require_xmm_ccf": '${REQUIRE_XMM_CCF}',
+                "require_chandra": '${REQUIRE_CHANDRA}',
+                "require_xspec_models": '${REQUIRE_XSPEC_MODELS}'
               }
              }'

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -168,7 +168,6 @@ jobs:
         run: |
           echo "pre-commit.ci checks passed on branch ${TARGET_BRANCH}. Triggering CircleCI."
           echo "Notebooks to build: ${NOTEBOOKS_TO_BUILD}"
-          echo "Required calibration datasets: ${REQUIRED_CALIBRATION_SETS}"
 
           # Post request to CircleCI API v2 to trigger a new pipeline
           # We pass arguments to the pipeline via the 'parameters' field, which

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -123,17 +123,13 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Install Jupytext
         id: install_jupytext
         if: success() && steps.which_notebooks_to_build.outputs.notebooks_to_build != ''
         run: |
-          # Make a one entry requirements (the setup-python action uses it to cache
-          #  dependencies, though admittedly this is probably overkill)
-          printf '%s\n' 'jupytext' > requirements.txt
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r jupytext
 
       - name: Determine which calibration datasets are required
         id: which_cal_data

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -117,6 +117,41 @@ jobs:
           # Export the variable for the next step
           echo "notebooks_to_build=$NOTEBOOKS_TO_BUILD" >> $GITHUB_OUTPUT
 
+      - name: Setup Python
+        id: setup_python
+        if: success() && steps.which_notebooks_to_build.outputs.notebooks_to_build != ''
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install Jupytext
+        id: install_jupytext
+        if: success() && steps.which_notebooks_to_build.outputs.notebooks_to_build != ''
+        run: |
+          # Make a one entry requirements (the setup-python action uses it to cache
+          #  dependencies, though admittedly this is probably overkill)
+          printf '%s\n' 'jupytext' > requirements.txt
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Determine which calibration datasets are required
+        id: which_cal_data
+        if: success() && steps.which_notebooks_to_build.outputs.notebooks_to_build != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          NOTEBOOKS_TO_BUILD: ${{ steps.which_notebooks_to_build.outputs.notebooks_to_build }}
+        run: |
+          python .github/workflows/collate-cal-files.py
+
+      - name: Fail if any calibration metadata is invalid
+        if: steps.which_cal_data.outputs.any_bad_cal_spec == 'true'
+        env:
+          BAD_CAL_SPEC: ${{ steps.which_cal_data.outputs.bad_cal_spec }}
+        run: |
+          echo "::error title=Invalid calibration metadata::$BAD_CAL_SPEC"
+          exit 1
 
       - name: Trigger CircleCI Pipeline via API
         # Only proceed if the wait step succeeded, and the 'skip-doc-build' label wasn't added to the PR (could be
@@ -130,6 +165,7 @@ jobs:
           PROJECT_SLUG: 'circleci/LdzbTUR6aexSM6vJCVrZk5/GRoaAeYuJNgCdifZviG612'
           CHECKOUT_REPO: 'HEASARC/heasarc-tutorials'
           NOTEBOOKS_TO_BUILD: ${{ steps.which_notebooks_to_build.outputs.notebooks_to_build }}
+          REQUIRED_CALIBRATION_SETS: ${{ steps.which_cal_data.outputs.required_cal_sets }}
 
         run: |
           echo "pre-commit.ci checks passed on branch ${TARGET_BRANCH}. Triggering CircleCI."
@@ -147,6 +183,7 @@ jobs:
               "config": {"branch": "'"${TARGET_BRANCH}"'"},
               "checkout": {"branch": "'"${TARGET_BRANCH}"'"},
               "parameters": {
-                "notebooks_to_build": "'"${NOTEBOOKS_TO_BUILD}"'"
+                "notebooks_to_build": "'"${NOTEBOOKS_TO_BUILD}"'",
+                "required_calibration_sets": "'"${REQUIRED_CALIBRATION_SETS}"'"
               }
              }'

--- a/notebook-templates/bite_sized_notebook_template.md
+++ b/notebook-templates/bite_sized_notebook_template.md
@@ -5,7 +5,7 @@ authors:
   email: djturner@umbc.edu
   orcid: 0000-0001-9658-1396
   website: https://davidt3.github.io/
-date: '2026-02-11'
+date: '2026-06-01'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -18,7 +18,10 @@ kernelspec:
   language: python
   name: heasoft
 execution:
-  cal-files: ['xmm-ccf', 'chandra', 'xspec-models']
+  cal-files:
+    xmm-ccf: True
+    chandra: True
+    xspec-models: True
 title: How to make a tutorial notebook in the HEASARC-tutorials repository
 ---
 
@@ -36,7 +39,7 @@ The following information must be added:
 - Date:
   - The date this notebook was last updated, following the year-month-day format.
 - Execution:
-  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Allowed values are shown in the template front-matter above, prepending '~' (e.g. '~xmm-ccf') will load all calibration files apart from xmm-ccf.
+  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Each entry may have a value of True or False. HEASoft's CalDB does not have an entry because these notebooks are set up to use remote CalDB files.
 
 
 ## Learning Goals

--- a/notebook-templates/bite_sized_notebook_template.md
+++ b/notebook-templates/bite_sized_notebook_template.md
@@ -17,10 +17,27 @@ kernelspec:
   display_name: heasoft
   language: python
   name: heasoft
+execution:
+  cal-files: ['xmm-ccf', 'chandra', 'xspec-models']
 title: How to make a tutorial notebook in the HEASARC-tutorials repository
 ---
 
 # Title: How to make a bite-sized HEASARC-tutorials notebook
+
+One of your first steps in adapting this template should be to fill out the 'front-matter' at the very top of the
+Markdown file - the contents of the front-matter are all metadata, to be used in different ways by different
+parts of the HEASARC-tutorials infrastructure.
+
+The following information must be added:
+- Authors:
+  - Anyone who you consider an author of this notebook, following the traditional 'first author contributed the most' ordering.
+  - Affiliations must be included, either as a list or a string.
+  - Email, ORCID, and personal website are optional, but please consider including them if you have them, as we will produce a DOI for this resource.
+- Date:
+  - The date this notebook was last updated, following the year-month-day format.
+- Execution:
+  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Allowed values are shown in the template front-matter above, prepending '~' (e.g. '~xmm-ccf') will load all calibration files apart from xmm-ccf.
+
 
 ## Learning Goals
 

--- a/notebook-templates/notebook_template.md
+++ b/notebook-templates/notebook_template.md
@@ -5,7 +5,7 @@ authors:
   email: djturner@umbc.edu
   orcid: 0000-0001-9658-1396
   website: https://davidt3.github.io/
-date: '2026-01-19'
+date: '2026-06-01'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -18,7 +18,10 @@ kernelspec:
   language: python
   name: heasoft
 execution:
-  cal-files: ['xmm-ccf', 'chandra', 'xspec-models']
+  cal-files:
+    xmm-ccf: True
+    chandra: True
+    xspec-models: True
 title: How to make a tutorial notebook in the HEASARC-tutorials repository
 ---
 
@@ -36,7 +39,7 @@ The following information must be added:
 - Date:
   - The date this notebook was last updated, following the year-month-day format.
 - Execution:
-  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Allowed values are shown in the template front-matter above, prepending '~' (e.g. '~xmm-ccf') will load all calibration files apart from xmm-ccf.
+  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Each entry may have a value of True or False. HEASoft's CalDB does not have an entry because these notebooks are set up to use remote CalDB files.
 
 
 ## Learning Goals

--- a/notebook-templates/notebook_template.md
+++ b/notebook-templates/notebook_template.md
@@ -17,10 +17,27 @@ kernelspec:
   display_name: heasoft
   language: python
   name: heasoft
+execution:
+  cal-files: ['xmm-ccf', 'chandra', 'xspec-models']
 title: How to make a tutorial notebook in the HEASARC-tutorials repository
 ---
 
 # Title: How to make a tutorial notebook in the HEASARC-tutorials repository
+
+One of your first steps in adapting this template should be to fill out the 'front-matter' at the very top of the
+Markdown file - the contents of the front-matter are all metadata, to be used in different ways by different
+parts of the HEASARC-tutorials infrastructure.
+
+The following information must be added:
+- Authors:
+  - Anyone who you consider an author of this notebook, following the traditional 'first author contributed the most' ordering.
+  - Affiliations must be included, either as a list or a string.
+  - Email, ORCID, and personal website are optional, but please consider including them if you have them, as we will produce a DOI for this resource.
+- Date:
+  - The date this notebook was last updated, following the year-month-day format.
+- Execution:
+  - 'cal-files' specifies the calibration files that will be needed to run this notebook. This information is both useful to the user and to the HEASARC-tutorials execution infrastructure, where it ensures we don't have to load all possible calibration files for every notebook. Allowed values are shown in the template front-matter above, prepending '~' (e.g. '~xmm-ccf') will load all calibration files apart from xmm-ccf.
+
 
 ## Learning Goals
 

--- a/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
+++ b/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
@@ -25,8 +25,7 @@ execution:
   cal-files:
     xmm-ccf: False
     chandra: False
-    xspec-models: ting
-    astrosat: False
+    xspec-models: True
 title: Getting started with preprocessed IXPE data
 ---
 
@@ -249,7 +248,8 @@ explorative stage where we use the name of our target, and its coordinates, to f
 What we do need to know is where the data are stored, and to retrieve a link that we can use to download them - we
 can achieve this using the IXPE summary table of observations, accessed using `astroquery`.
 
-The name of the observation table is stored in the `HEASARC_TABLE_NAME` constant, set up in the collapsed 'Global Setup: Constants' subsection above:
+The name of the observation table is stored in the `HEASARC_TABLE_NAME` constant, set up in the collapsed
+['Global Setup: Constants'](#constants) subsection above:
 
 ```{code-cell} python
 HEASARC_TABLE_NAME
@@ -459,7 +459,6 @@ Now we use the HEASARC tool to actually fetch the response files:
 
 ```{code-cell} python
 # Getting the on-axis RMFs, ARFs, and MRFs
-
 resps = {det: {"rmf": None, "arf": None, "mrf": None} for det in evt_file_paths.keys()}
 
 for det in evt_file_paths.keys():
@@ -547,6 +546,8 @@ xs.AllData.clear()
 # Dictionary to store sort detector responses into - makes it neater to load them in
 resps = {det: resps[det] for det in sorted(resps)}
 
+# Changing directory to the directory we've been writing spectra to, we now
+#  load them into PyXspec.
 with contextlib.chdir(OUT_PATH):
     x = 0  # Iterator index to keep the spectrum numbering correct
     for det, supp_files in resps.items():

--- a/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
+++ b/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
@@ -25,7 +25,8 @@ execution:
   cal-files:
     xmm-ccf: False
     chandra: False
-    xspec-models: True
+    xspec-models: ting
+    astrosat: False
 title: Getting started with preprocessed IXPE data
 ---
 
@@ -154,6 +155,7 @@ jupyter:
 ---
 # IXPE ObsID that we will use for this example.
 OBS_ID = "01004701"
+# The source name as well
 SRC_NAME = "Mrk 501"
 
 # The name of the HEASARC table that logs all IXPE observations

--- a/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
+++ b/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
@@ -21,6 +21,11 @@ kernelspec:
   display_name: heasoft
   language: python
   name: heasoft
+execution:
+  cal-files:
+    xmm-ccf: False
+    chandra: False
+    xspec-models: True
 title: Getting started with preprocessed IXPE data
 ---
 

--- a/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
+++ b/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
@@ -542,10 +542,10 @@ then to ensure that the working directory is reset.
 ```{code-cell} python
 xs.AllData.clear()
 
+# Dictionary to store sort detector responses into - makes it neater to load them in
 resps = {det: resps[det] for det in sorted(resps)}
 
 with contextlib.chdir(OUT_PATH):
-
     x = 0  # Iterator index to keep the spectrum numbering correct
     for det, supp_files in resps.items():
         du = int(det[-1])

--- a/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
+++ b/tutorials/mission_specific_analyses/ixpe/data-analysis-ixpe.md
@@ -9,7 +9,7 @@ authors:
   email: djturner@umbc.edu
   orcid: 0000-0001-9658-1396
   website: https://davidt3.github.io/
-date: '2026-02-02'
+date: '2026-06-01'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -110,7 +110,7 @@ def extract_spec(inst: str, region_file: str):
     :param inst: The instrument name (e.g. 'det1', 'det2', 'det3')
     :param region_file: The region file to use for extraction.
     """
-
+    # Setup the full path where we wish to write the new spectrum
     spec_out = os.path.join(
         OUT_PATH,
         "ixpe_{i}_{r}_.pha".format(i=inst.lower(), r=region_file.split(".")[0]),
@@ -179,11 +179,33 @@ mp.set_start_method("fork", force=True)
 
 
 # ------------- Setting how many cores we can use --------------
-NUM_CORES = None
+# We use a service called CircleCI to execute, test, and validate these notebooks
+#  as we're writing and maintaining them. Unfortunately we have to treat the
+#  determination of the number of cores we can use differently, as the
+#  'os.cpu_count()' call will return the number of cores of the host machine, rather
+#  than the number that have actually been allocated to us.
+if "CIRCLECI" in os.environ and bool(os.environ["CIRCLECI"]):
+    # Here we read the CPU quota (total CPU time allowed) and the CPU period (how
+    #  long the scheduling window is) from a cgroup (a linux kernel feature) file.
+    # Dividing one by t'other provides the number of cores we've been allocated.
+    with open("/sys/fs/cgroup/cpu.max", "r") as cpu_maxo:
+        quota, period = cpu_maxo.read().strip().split()
+        NUM_CORES = int(quota) // int(period)
+
+# If you, the reader, are running this notebook yourself, this is the
+#  part that is relevant to you - you can override the default number of cores
+#  used by setting this variable to an integer value.
+else:
+    NUM_CORES = None
+
+# Determines the number of CPU cores available
 total_cores = os.cpu_count()
 
+# If NUM_CORES is None, then we use the number of cores returned by 'os.cpu_count()'
 if NUM_CORES is None:
     NUM_CORES = total_cores
+# Otherwise, NUM_CORES has been overridden (either by the user, or because we're
+#  running on CircleCI, and we do a validity check.
 elif not isinstance(NUM_CORES, int):
     raise TypeError(
         "If manually overriding 'NUM_CORES', you must set it to an integer value."
@@ -321,7 +343,7 @@ Here we get to the fun part - the creation and analysis of some IXPE data produc
 
 ### Defining source and background regions
 
-To obtain source and background spectra from the 'level 2' files, we need to define source and background regions for
+To obtain source and background spectra from the 'level 2' event lists, we need to define source and background regions for
 the extraction.
 
 Defining regions can be done in a number of ways, using automated source finding tools, drawing them onto
@@ -488,17 +510,17 @@ for det in evt_file_paths.keys():
     ][0]
 ```
 
-## 4. Loading spectro-polarimetric data into pyXspec and fitting a model
+## 4. Loading spectro-polarimetric data into PyXspec and fitting a model
 
-We now have everything we need to load the extracted spectra into pyXspec and fit a model to them!
+We now have everything we need to load the extracted spectra into PyXspec and fit a model to them!
 
 ### Configuring PyXspec
 
-Here we configure some of pyXspec's behaviors. We set the verbosity to '0' to suppress printed output, make sure the
+Here we configure some of PyXspec's behaviors. We set the verbosity to '0' to suppress printed output, make sure the
 plot axes are energy (for the x-axis), and normalized counts per second (for the y-axis).
 
 ```{code-cell} python
-# Severely imits the output of pyXspec, though chatter = 0 will still
+# Severely imits the output of PyXspec, though chatter = 0 will still
 #  let some messages through.
 xs.Xset.chatter = 0
 
@@ -510,10 +532,10 @@ xs.Fit.query = "no"
 xs.Fit.nIterations = 500
 ```
 
-### Reading the spectra into pyXspec
+### Reading the spectra into PyXspec
 
 This snippet uses our previously defined `resps` dictionary to load the spectra and their requisite response files
-into pyXspec. The 'I', 'U', and 'Q' spectra are all loaded in for each detector. The 'contextlib.chdir' statement is
+into PyXspec. The 'I', 'U', and 'Q' spectra are all loaded in for each detector. The 'contextlib.chdir' statement is
 used to change the working directory to the directory containing spectral files so that the spectra can be loaded, and
 then to ensure that the working directory is reset.
 
@@ -614,7 +636,7 @@ m2.constant.factor = 0.8
 m3.constant.factor = 0.9
 ```
 
-### Running the model fit through pyXspec
+### Running the model fit through PyXspec
 
 ```{code-cell} python
 xs.Fit.perform()
@@ -630,12 +652,12 @@ xs.Xset.chatter = 0
 
 ## 5. Visualizing the results
 
-We will now extract information from pyXspec and plot various aspects of the fitted models and results using the
-`matplotlib` package. This offers more flexibility than the built-in plotting functions in pyXspec.
+We will now extract information from PyXspec and plot various aspects of the fitted models and results using the
+`matplotlib` package. This offers more flexibility than the built-in plotting functions in PyXspec.
 
 ### A 'traditional' X-ray spectrum
 
-We can fetch the count rate, and energy bin centers, from pyXspec:
+We can fetch the count rate, and energy bin centers, from PyXspec:
 
 ```{code-cell} python
 # This command will construct a logged-data plot of the spectrum
@@ -832,7 +854,7 @@ for sp_ind in [1, 4, 7]:
 flux_ispec
 ```
 
-Now we can easily calculate a mean flux:
+Now we can easily calculate the mean flux:
 
 ```{code-cell} python
 np.mean(flux_ispec)
@@ -856,7 +878,7 @@ Author: Kavitha Arur, IXPE GOF Scientist
 
 Author: David J Turner, HEASARC Staff Scientist
 
-Updated On: 2026-02-02
+Updated On: 2026-06-01
 
 +++
 


### PR DESCRIPTION
The front-matter of a HEASARC-tutorials markdown notebook now has a 'execution' section, where any meta-data relevant to how or when the notebook is executed is included. The first (and only, at least so far) section is 'cal-files', with three boolean parameters:

```
    xmm-ccf: False
    chandra: False
    xspec-models: True
```

the idea being that setting one of these to true causes the execution pipeline to make sure we have those calibration files cached on CircleCI, and if not download them (but _only_ the calibration set specified, unlike now where they are all checked and downloaded/cached _every_ time).

This should allow us to avoid issue #266 until the ESA rsync service is fixed, as well as actually speeding up the caching and execution jobs in the CircleCI workflow.

Some small changes have been made to the IXPE demonstration, to trigger the rebuild for testing.