### PR TITLE
Now specify host and download location as keyword arguments to astroquery download_data call in Swift XRT tutorial

### DIFF
--- a/.github/workflows/populate-production-notebooks.yml
+++ b/.github/workflows/populate-production-notebooks.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           # Find all .md files in main-branch/tutorials, excluding templates, READMEs, and index files
           find main-branch/tutorials -name "*.md" -type f | \
-            grep -vE "(notebook_template|pull_request_template|README|index|\.ipynb_checkpoints)" | \
+            grep -vE "(notebook_template|CODE_OF_CONDUCT|CONTRIBUTING|pull_request_template|README|index|\.ipynb_checkpoints)" | \
             sort > /tmp/main_notebooks.txt
 
           # Create list of notebooks that need updating (new files or files with differences)

--- a/.github/workflows/trigger-circleci.yml
+++ b/.github/workflows/trigger-circleci.yml
@@ -67,7 +67,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Define the exclusion patterns
-          EXCLUDE_PATTERNS=("*notebook_template*" "*pull_request_template*" "*README*" "**/*README*" "*.ipynb_checkpoints*")
+          EXCLUDE_PATTERNS=("*notebook_template*" "*pull_request_template*" "*README*" "**/*README*" "*.ipynb_checkpoints*" "*CONTRIBUTING*" "*CODE_OF_CONDUCT*")
 
           # First, check if there's an override pattern in PR comments
           OVERRIDE_NOTEBOOKS=$(curl -s \

--- a/conf.py
+++ b/conf.py
@@ -19,8 +19,9 @@ version = '0.1'
 extensions = ['myst_nb', 'sphinx_copybutton', 'sphinx.ext.mathjax']
 
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.tox', '.tmp', '.pytest_cache', 'README.md',
-                    '**/*_template*', '**/README.md', '*_template*']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.tox', '.tmp', '.pytest_cache',
+                    'README.md', 'CONTRIBUTING.md', 'CODE_OF_CONDUCT.md', '**/*_template*',
+                    '**/README.md', '*_template*']
 
 # Registering custom JS files
 #  1. Adds a surface level password-unlocked screen over the website
@@ -61,7 +62,8 @@ def check_poss_nb(file_name):
 
 # These patterns will always be excluded
 BASE_EXCLUDE_PATTERNS = ['*notebook_template*', '*pull_request_template*', '*README*',
-                         '**/*README*', '*.ipynb_checkpoints*']
+                         '**/*README*', '*.ipynb_checkpoints*', '*CONTRIBUTING*',
+                         '*CODE_OF_CONDUCT*']
 
 # We allow a 'HEASARC_NOTEBOOKS_TO_BUILD' environment variable to be set, which should
 #  have the form:

--- a/conf.py
+++ b/conf.py
@@ -29,6 +29,14 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.tox', '.tmp', '.pytest
 html_js_files = []
 # ----------------------------------------------------------------------------
 
+# --------------------------- Sphinx configuration ---------------------------
+# Suppressing highlight_failure to deal with Sphinx's complaints about using ?
+#  symbols to access help docstrings in Jupyter notebooks.
+suppress_warnings = [
+    "misc.highlighting_failure",
+]
+# ----------------------------------------------------------------------------
+
 # ---------------------------- MyST configuration ----------------------------
 # MyST-NB configuration
 nb_execution_timeout = 1200

--- a/tutorials/mission_specific_analyses/swift/getting-started-swift-xrt.md
+++ b/tutorials/mission_specific_analyses/swift/getting-started-swift-xrt.md
@@ -9,7 +9,7 @@ authors:
   affiliations: ["Michigan State University"]
   orcid: 0000-0002-3673-0668
   website: https://adkpete.github.io/
-date: '2025-12-23'
+date: '2026-07-30'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -554,7 +554,7 @@ observation, which will include BAT and UVOT instrument files that are not relev
 to this tutorial.
 
 ```{code-cell} python
-Heasarc.download_data(data_links, "aws", ROOT_DATA_DIR)
+Heasarc.download_data(data_links, host="aws", location=ROOT_DATA_DIR)
 ```
 
 ```{note}
@@ -1519,7 +1519,7 @@ Author: David Turner, HEASARC Staff Scientist
 
 Author: Peter Craig, Michigan State University Research Associate
 
-Updated On: 2025-12-23
+Updated On: 2026-07-30
 
 +++
 

--- a/tutorials/mission_specific_analyses/swift/getting-started-swift-xrt.md
+++ b/tutorials/mission_specific_analyses/swift/getting-started-swift-xrt.md
@@ -21,6 +21,11 @@ kernelspec:
   display_name: heasoft
   language: python
   name: heasoft
+execution:
+  cal-files:
+    xmm-ccf: False
+    chandra: False
+    xspec-models: False
 title: Getting started with Swift-XRT
 ---
 


### PR DESCRIPTION
We moved from:

```python
Heasarc.download_data(data_links, "aws", ROOT_DATA_DIR)
```

to 

```python
Heasarc.download_data(data_links, host="aws", location=ROOT_DATA_DIR)
```

This is future proofs the notebook to a change coming in the next astroquery release.