### PR TITLE
Now specify host and download location as keyword arguments to astroquery download_data call in RASS tutorial

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,11 +2,11 @@
 
 This repository follows the [NASA Policies and Guidelines for Digital and  Social Media](https://www.nasa.gov/nasa-policies-and-guidelines-for-digital-and-social-media/) and [NASA policies](https://nodis3.gsfc.nasa.gov/main_lib.cfm).
 
-The maintainers are committed to providing a friendly, safe, and welcoming environment for all.  For more information about how to contribute to the HEASARC-Tutorials project, please see our [Contributors Guide](./Contributing.md).
+The maintainers are committed to providing a friendly, safe, and welcoming environment for all.  For more information about how to contribute to the HEASARC-Tutorials project, please see our [Contributors Guide](./CONTRIBUTING.md).
 
 The contributions posted should deal with NASA’s institutional work and to the specific topic of the repository. If your contribution is not relevant to the post or to NASA’s work, the contribution may be removed.  The contributions to the repository must be appropriate for everyone.  Contributions that include vulgar, sexually explicit, drug-related, abusive, offensive, violent, threatening, or harassing language that impedes or disrupts NASA’s mission may be removed.
 
-The license for this repository is available [here](./LICENSE.MD)
+The license for this repository is available [here](./LICENSE)
 
 ## Resources
 

--- a/tutorials/mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.md
+++ b/tutorials/mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.md
@@ -1043,6 +1043,7 @@ tags: [hide-input]
 jupyter:
   source_hidden: true
 ---
+# Creating the grid visualization of all our sources
 num_cols = 4
 fig_side_size = 3
 

--- a/tutorials/mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.md
+++ b/tutorials/mission_specific_analyses/rosat/getting-started-rosat-all-sky-survey.md
@@ -9,7 +9,7 @@ authors:
   affiliations: [The Catholic University of America, 'HEASARC, NASA Goddard']
   orcid: 0000-0002-7762-3172
   website: https://science.gsfc.nasa.gov/sci/bio/michael.f.corcoran
-date: '2026-03-12'
+date: '2026-07-30'
 file_format: mystnb
 jupytext:
   text_representation:
@@ -25,7 +25,7 @@ execution:
   cal-files:
     xmm-ccf: False
     chandra: False
-    xspec-models: True
+    xspec-models: False
 title: Getting started with ROSAT All Sky Survey data
 ---
 
@@ -950,7 +950,7 @@ tags: [hide-output]
 jupyter:
   output_hidden: true
 ---
-Heasarc.download_data(rass_data_links, "aws", ROOT_DATA_DIR)
+Heasarc.download_data(rass_data_links, host="aws", location=ROOT_DATA_DIR)
 ```
 
 ### What is included in the downloaded data?
@@ -2420,7 +2420,7 @@ Author: David Turner, HEASARC Staff Scientist
 
 Author: Mike Corcoran, Associate Research Professor
 
-Updated On: 2026-03-12
+Updated On: 2026-07-30
 
 +++
 


### PR DESCRIPTION
We moved from:

```python
Heasarc.download_data(data_links, "aws", ROOT_DATA_DIR)
```

to 

```python
Heasarc.download_data(data_links, host="aws", location=ROOT_DATA_DIR)
```

This is future proofs the notebook to a change coming in the next astroquery release.